### PR TITLE
redo order of operations

### DIFF
--- a/shastra_compedium/views/source_list.py
+++ b/shastra_compedium/views/source_list.py
@@ -43,13 +43,14 @@ class SourceList(GenericList):
                             'details': [cat_detail]}
                 else:
                     source_dict[source] = {
-                            cat_detail.category: {'positions': [],
-                                                  'details': [cat_detail]},
+                        cat_detail.category: {'positions': [],
+                                              'details': [cat_detail]},
                     }
-        for source in Source.objects.filter(categorydetail=None):
-            source_dict[source] = {'chapters': []}
         for pos in PositionDetail.objects.all():
             for source in pos.sources.all():
+                if source not in source_dict:
+                    source_dict[source] = {}
+
                 if pos.position.category in source_dict[source]:
                     if pos.position not in source_dict[source][
                             pos.position.category]['positions']:
@@ -59,5 +60,7 @@ class SourceList(GenericList):
                     source_dict[source][pos.position.category] = {
                         'positions': [pos.position],
                         'details': []}
-
+        for source in Source.objects.filter(categorydetail=None,
+                                            positiondetail=None):
+            source_dict[source] = {'chapters': []}
         return source_dict


### PR DESCRIPTION
The old order meant that sources with no category detiails got an extra 'chapter' item that created the phantom row.

This is close to a 1 line code change.